### PR TITLE
FD-54 Add scrollbar to charts

### DIFF
--- a/site/assets/scripts/chart.js
+++ b/site/assets/scripts/chart.js
@@ -1,6 +1,8 @@
 var chartInstance = null;
 var rendered = false;
 var activeBar = 0;
+const breakpoints = [0,576,768];
+const scale = breakpoints.findLastIndex((w) => window.innerWidth > w) + 1;
 
 function createChart (sessions, fnCallback) {
     var hoverLabels = [];
@@ -42,17 +44,31 @@ function createChart (sessions, fnCallback) {
                                 return value;
                             }
                         }
-                    }
+                    },
                 },
             },
             responsive: true,
             maintainAspectRatio: false,
             plugins: {
                 legend: {
-                display: false
+                    display: false
                 },
                 tooltip: {
-                    xAlign: 'center',
+                    xAlign: function(tip) {
+                        // dynamically set tooltip alignment based on bar position within scroll area
+                        const containerWidth = tip.tooltip.chart.canvas.parentNode.parentElement.clientWidth;
+                        const chartWidth = tip.tooltip.chart.canvas.parentNode.parentElement.scrollWidth;
+                        const scrollPos = tip.tooltip.chart.canvas.parentNode.parentElement.scrollLeft;
+                        const axisWidth = tip.tooltip.chart.scales.y.width;
+
+                        if (tip.tooltip.dataPoints[0].element.x < scrollPos + axisWidth + (chartWidth * .05)) {
+                            return 'left';
+                        } else if (chartWidth - tip.tooltip.dataPoints[0].element.x + scrollPos < chartWidth - containerWidth + (chartWidth * .05)) {
+                            return 'right';
+                        } else {
+                            return 'center';
+                        }
+                    },
                     yAlign: 'bottom',
                     backgroundColor: '#FFFFFF',
                     bodyColor: '#000000',
@@ -86,6 +102,35 @@ function createChart (sessions, fnCallback) {
         plugins: [{
             afterDraw: function(chart) {
                 if (!rendered) {
+                    if (chart.data.datasets[0].data.length >= scale*10) {
+                        const axisWidth = chart.scales.y.width;
+                        const containerWidth = chart.canvas.parentNode.parentElement.clientWidth;
+                        // add scrollbar class to container
+                        chart.canvas.parentNode.parentElement.classList.add('scrollbar');
+                        // calculate total size of chart width
+                        const barWidth = (containerWidth - axisWidth) / (scale*10);
+                        const totalWidth = barWidth * chart.data.datasets[0].data.length + axisWidth;
+                        chart.canvas.parentNode.style.width = totalWidth + 'px';
+                        
+                        // copy Y Axis scale to second static canvas element 
+                        const dScale = window.devicePixelRatio; 
+                        const sourceCanvas = chart.canvas;
+                        const axisHeight = chart.scales.y.maxHeight;
+                        const targetCtx = document.getElementById("chartYAxis").getContext("2d");
+                        targetCtx.scale(dScale, dScale);
+                        targetCtx.canvas.width = axisWidth * dScale;
+                        targetCtx.canvas.height = axisHeight * dScale;
+                        targetCtx.canvas.style.width = `${axisWidth}px`;
+                        targetCtx.canvas.style.height = `${axisHeight}px`;
+                        targetCtx.drawImage(sourceCanvas, 0, 0, axisWidth * dScale, axisHeight * dScale, 0, 0, axisWidth * dScale, axisHeight * dScale);
+                        const sourceCtx = sourceCanvas.getContext('2d');
+                        // normalize coordinate system to use css pixels.
+                        sourceCtx.clearRect(0, 0, axisWidth * dScale, axisHeight * dScale);
+                        // scroll to active element
+                        chart.canvas.parentNode.parentNode.scroll((totalWidth - containerWidth), 0);
+                        // update scroll position on window resize
+                        window.addEventListener('resize', setScroll);
+                    }
                     // set active element on initial chart draw
                     chart.setActiveElements([
                         {
@@ -107,29 +152,9 @@ function createChart (sessions, fnCallback) {
                     ]);
                     chart.update();
                 }
-            }
+            },
         }]
     });
-}
-
-function updateOrCreateChart(sessions, fnCallback) {
-    // Create chart if it isn't already created.
-    if (chartInstance === null) {
-        createChart(sessions, fnCallback);
-        return;
-    }
-    // Else update
-    var hoverLabels = [];
-    var displaySessions = [];
-
-    sessions.forEach(element => {
-        hoverLabels.push(element.label);
-        displaySessions.push(element.totalSessions);
-    });
-
-    chartInstance.data.labels = hoverLabels;
-    chartInstance.data.datasets[0].data = displaySessions;
-    chartInstance.update();
 }
 
 function setActiveBar(index) {
@@ -141,6 +166,28 @@ function setActiveBar(index) {
       }
     ]);
     chartInstance.update();
+
+    if (chartInstance.data.datasets[0].data.length >= scale*10) {
+        // Scroll to active element
+        setScroll();
+    }
 }
 
-export { createChart, updateOrCreateChart, setActiveBar }
+function setScroll() {
+    const clientWindow = chartInstance.canvas.parentNode.parentElement.clientWidth;
+    const scrollPos = chartInstance.canvas.parentNode.parentElement.scrollLeft;
+    const barEl = chartInstance.getActiveElements()[0].element;
+    const catWidth = barEl.width / 0.9; // 0.9 = default bar percentage within category
+    const axisWidth = chartInstance.scales.y.width;
+
+    if ((barEl.x > scrollPos + axisWidth) && (barEl.x < scrollPos + clientWindow))
+    {
+        // bar Position within view, don't need to scroll
+        return;
+    }
+    const scrollNew = barEl.x < (scrollPos - axisWidth + clientWindow) ? Math.max(0, barEl.x - clientWindow + axisWidth - catWidth/2) : barEl.x - axisWidth - catWidth/2;
+ 
+    chartInstance.canvas.parentNode.parentNode.scroll(scrollNew, 0);
+}
+
+export { createChart, setActiveBar }

--- a/site/assets/scripts/game_usage.js
+++ b/site/assets/scripts/game_usage.js
@@ -1,5 +1,5 @@
 import { getGameUsage, getGameFiles } from "../scripts/services.js";
-import { createChart, updateOrCreateChart, setActiveBar } from "../scripts/chart.js";
+import { createChart, setActiveBar } from "../scripts/chart.js";
 import { GameUsage } from "../scripts/models.js";
 
 let gameId = null;
@@ -7,6 +7,7 @@ let currentMonth = null;
 let currentYear = null;
 const prevMonth = document.getElementById('month-prev');
 const nextMonth = document.getElementById('month-next');
+const chartWrapEl = document.getElementById('chart-wrapper');
 const chartEl = document.getElementById('chart');
 const statsHeader = document.getElementById('stats-header');
 const numPlays = document.getElementById('num-plays');
@@ -26,7 +27,6 @@ const featureBtn = document.getElementById('feature-btn');
 
 let gameUsage = null;
 let currentSession = null;
-let updateChart = false;
 
 document.addEventListener('DOMContentLoaded', () => {
     let params = new URLSearchParams(document.location.search);
@@ -55,15 +55,12 @@ document.addEventListener('DOMContentLoaded', () => {
             // update the game usage information
             var monthlySessions = currentSession.total_sessions < 1000 ? currentSession.total_sessions : (currentSession.total_sessions / 1000).toFixed(0) + 'K';
             numPlays.innerHTML = monthlySessions + ' sessions';
-            // create the chart
-            chartEl.style.height = '200px';
-            chartEl.classList.add('mb-3');
-
-            if (gameUsage.chartSessions.length > 30) {
-                // slice the chart sessions array to 30 elements
-                gameUsage.chartSlice(gameUsage.chartSessions.length-30, gameUsage.chartSessions.length);    
-            } 
-            createChart(gameUsage.chartSessions, goToMonth);
+            if (gameUsage.sessions.some(e => e.total_sessions > 0)) {
+                // create the chart
+                chartEl.style.height = '200px';
+                chartWrapEl.classList.add('mb-3');
+                createChart(gameUsage.chartSessions, goToMonth);
+            }
         }
     });
 
@@ -141,15 +138,6 @@ let bindPipelineButtonClickEvents = function () {
 }
 
 var prevMonthFunc = function () {
-    // find the current chart array index
-    var chartIndex = gameUsage.chartSessions.findIndex(e => e.month === currentMonth && e.year === currentYear);
-    // find the full sessions array index
-    var sessionIndex = gameUsage.sessions.findIndex(e => e.month === currentMonth && e.year === currentYear);
-    if (chartIndex === 0) {
-        // update the chart array with subset of full sessions array
-        gameUsage.chartSlice(Math.max(0,sessionIndex - 30), sessionIndex);
-        updateChart = true;
-    }
     // setup year and month
     // we were in January, move back to December of previous year
     if (currentMonth === 1) {
@@ -164,15 +152,6 @@ var prevMonthFunc = function () {
 }
 
 var nextMonthFunc = function () {
-    // find the current chart array index
-    var chartIndex = gameUsage.chartSessions.findIndex(e => e.month === currentMonth && e.year === currentYear);
-    // find the full sessions array index
-    var sessionIndex = gameUsage.sessions.findIndex(e => e.month === currentMonth && e.year === currentYear);
-    if (chartIndex === gameUsage.chartSessions.length-1) {
-        // update the chart array with subset of full sessions array
-        gameUsage.chartSlice(sessionIndex+1, Math.min(sessionIndex+31, gameUsage.sessions.length));
-        updateChart = true;
-    }
     // setup year and month
     // we were in December, move to January of next year
     if (currentMonth === 12) {
@@ -205,17 +184,10 @@ function updateHtml(gameId, currentYear, currentMonth) {
         currentSession = gameUsage.sessions.find(e => e.month === currentMonth && e.year === currentYear);
         var monthlySessions = currentSession.total_sessions < 1000 ? currentSession.total_sessions : (currentSession.total_sessions / 1000).toFixed(0) + 'K';
         numPlays.innerHTML = currentSession.total_sessions > 0 ? monthlySessions + ' sessions' : 'No sessions';                    
-        // update or create the chart
-        if (updateChart) {
-            chartEl.style.height = '200px';
-            if (!chartEl.classList.contains('mb-3')) {
-                chartEl.classList.add('mb-3');
-            }
-            updateOrCreateChart(gameUsage.chartSessions, goToMonth); 
-            updateChart = false;
-        }
         var currentIndex = gameUsage.chartSessions.findIndex(e => e.month === currentMonth && e.year === currentYear);
-        setActiveBar(currentIndex);    
+        if (gameUsage.sessions.some(e => e.total_sessions > 0)) {
+            setActiveBar(currentIndex);
+        }
     }
 
     // get game files for that month

--- a/site/assets/scripts/game_usage.js
+++ b/site/assets/scripts/game_usage.js
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (gameUsage.sessions.some(e => e.total_sessions > 0)) {
                 // create the chart
                 chartEl.style.height = '200px';
-                chartWrapEl.classList.add('mb-3');
+                chartWrapEl.classList.add('mb-4');
                 createChart(gameUsage.chartSessions, goToMonth);
             }
         }

--- a/site/assets/scripts/models.js
+++ b/site/assets/scripts/models.js
@@ -19,13 +19,6 @@ class GameUsage {
         });
         return chartSessions;
     }
-
-    // Slice chart sessions array 
-    chartSlice(start, end) {
-        this.chartSessions = this.getChartSessions().slice(start, end);
-    }
-
-
 }
 
 class MonthlyUsage {
@@ -39,7 +32,6 @@ class MonthlyUsage {
     getMonthName() {
         return new Date(this.year, Number(this.month)-1).toLocaleString('default', { month: 'long' });
     }
-
 }
 
 export { GameUsage, MonthlyUsage };

--- a/site/assets/styles/scss/styles.scss
+++ b/site/assets/styles/scss/styles.scss
@@ -296,6 +296,7 @@ img.avatar {
         overflow-x: scroll;
         scrollbar-color: var(--scrollbar-foreground) var(--scrollbar-background);
         scrollbar-width: thin;
+        padding-bottom: 0.5rem;
         &::-webkit-scrollbar {
             width: 15px;
             height: 15px;

--- a/site/assets/styles/scss/styles.scss
+++ b/site/assets/styles/scss/styles.scss
@@ -319,7 +319,6 @@ img.avatar {
     }
     #chartYAxis {
         background-color: white;
-        pointer-events: none;
         left: -1px;
     }
 

--- a/site/assets/styles/scss/styles.scss
+++ b/site/assets/styles/scss/styles.scss
@@ -284,11 +284,42 @@ img.avatar {
         .btn-group-vertical>.btn~.btn{
             border-top-left-radius: .25rem;
             border-top-right-radius: .25rem;
-        }
+        }      
         .btn-group-vertical>.btn:not(:last-child):not(.dropdown-toggle){
             border-bottom-left-radius: .25rem;
             border-bottom-right-radius: .25rem;
         }
+    }
+    .scrollbar {
+        --scrollbar-foreground: #4D459E;
+        --scrollbar-background: #D7D4F1;
+        overflow-x: scroll;
+        scrollbar-color: var(--scrollbar-foreground) var(--scrollbar-background);
+        scrollbar-width: thin;
+        &::-webkit-scrollbar {
+            width: 15px;
+            height: 15px;
+        }
+        &::-webkit-scrollbar-thumb { /* Foreground */
+            background-color: var(--scrollbar-foreground);
+            border-radius: 7.5px;
+        }
+        &::-webkit-scrollbar-track { /* Background */
+            background: no-repeat linear-gradient(to bottom, white 20%, var(--scrollbar-background) 20%, var(--scrollbar-background) 80%, white 80%);
+        }
+    }
+    canvas {
+        position: absolute;
+        top: 0;
+        left: 0;
+    }
+    #chart {
+        width: auto;        
+    }
+    #chartYAxis {
+        background-color: white;
+        pointer-events: none;
+        left: -1px;
     }
 
     #templates{

--- a/site/includes/chart.php
+++ b/site/includes/chart.php
@@ -1,6 +1,10 @@
-<div id="chart">
-    <canvas id="activityChart" style="height: 0;"></canvas>
+<div class="position-relative">    
+    <div id="chart-wrapper" class="position-relative">
+        <div id="chart" class="position-relative">
+            <canvas id="activityChart" style="height: 0;"></canvas>
+        </div>
+    </div>
+    <canvas id="chartYAxis" height="0" width="0"></canvas>
 </div>
-
 <script src="assets/scripts/chart.umd.js"></script>
 <script type="module" src="assets/scripts/chart.js"></script>


### PR DESCRIPTION
Testing Instructions:
- Test both scrolling through the chart and stepping through with the month by month arrows.
- Test mobile and tablet sizes

**_Note:_** full scroll bar styling is only available on webkit (Chrome, Edge, Safari). Firefox uses standard `scrollbar-` elements but they are more limited. 